### PR TITLE
Pipeline orchestration and small fixes

### DIFF
--- a/data_factory.tf
+++ b/data_factory.tf
@@ -23,11 +23,11 @@ resource "azurerm_template_deployment" "lsdbks" {
 
   # these key-value pairs are passed into the ARM Template's `parameters` block
   parameters = {
-    "factoryName"    = azurerm_data_factory.df.name
-    "accessToken"    = databricks_token.token.token_value
-    "domain"         = format("https://%s.azuredatabricks.net", azurerm_databricks_workspace.dbks.location)
-    "databricksName" = azurerm_databricks_workspace.dbks.name
-    "clusterId"      = databricks_cluster.cluster.id
+    "factoryName"                 = azurerm_data_factory.df.name
+    "accessToken"                 = databricks_token.token.token_value
+    "domain"                      = format("https://%s.azuredatabricks.net", azurerm_databricks_workspace.dbks.location)
+    "databricksLinkedServiceName" = azurerm_databricks_workspace.dbks.name
+    "clusterId"                   = databricks_cluster.cluster.id
   }
 
   deployment_mode = "Incremental"

--- a/databricks.tf
+++ b/databricks.tf
@@ -69,9 +69,15 @@ resource "databricks_secret_scope" "synapse" {
   initial_manage_principal = "users"
 }
 
-resource "databricks_secret" "synapse" {
-  key          = "connection_string"
-  string_value = "jdbc:sqlserver://${azurerm_sql_server.synapse_srv.fully_qualified_domain_name}:1433;database=${azurerm_sql_database.synapse.name};user=${local.databricks_loader_user}@${azurerm_sql_server.synapse_srv.name};password=${random_password.sql_databricks_loader.result};encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;"
+resource "databricks_secret" "synapse_username" {
+  key          = "username"
+  string_value = "${local.databricks_loader_user}@${azurerm_sql_server.synapse_srv.name}"
+  scope        = databricks_secret_scope.synapse.name
+}
+
+resource "databricks_secret" "synapse_password" {
+  key          = "password"
+  string_value = random_password.sql_databricks_loader.result
   scope        = databricks_secret_scope.synapse.name
 }
 
@@ -133,7 +139,7 @@ resource "databricks_notebook" "spark_setup" {
       DATABRICKS_HOST  = format("https://%s.azuredatabricks.net", azurerm_databricks_workspace.dbks.location)
       DATABRICKS_TOKEN = databricks_token.token.token_value
       CLUSTER_ID       = databricks_cluster.cluster.id
-      NOTEBOOK_PATH    = databricks_notebook.spark_setup.path
+      NOTEBOOK_PATH    = self.path
     }
   }
 }

--- a/files/lsdbks.json
+++ b/files/lsdbks.json
@@ -11,7 +11,7 @@
         "domain": {
             "type": "string"
         },
-        "databricksName": {
+        "databricksLinkedServiceName": {
             "type": "string"
         },
         "clusterId": {
@@ -20,11 +20,10 @@
     },
     "resources": [
         {
-            "name": "[concat(parameters('factoryName'), '/', parameters('databricksName'))]",
+            "name": "[concat(parameters('factoryName'), '/', parameters('databricksLinkedServiceName'))]",
             "type": "Microsoft.DataFactory/factories/linkedServices",
             "apiVersion": "2018-06-01",
             "properties": {
-                "annotations": [],
                 "type": "AzureDatabricks",
                 "typeProperties": {
                     "domain": "[parameters('domain')]",
@@ -36,5 +35,15 @@
                 }
             }
         }
-    ]
+    ],
+    "outputs": {
+        "databricksLinkedServiceName": {
+            "type": "string",
+            "value": "[parameters('databricksLinkedServiceName')]"
+        },
+        "databricksLinkedServiceId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.DataFactory/factories/linkedServices', parameters('factoryName'), parameters('databricksLinkedServiceName'))]"
+        }
+    }
 }

--- a/files/sample_data/dfpipeline.json
+++ b/files/sample_data/dfpipeline.json
@@ -13,7 +13,8 @@
         }
     },
     "variables": {
-        "factoryId": "[concat('Microsoft.DataFactory/factories/', parameters('factoryName'))]"
+        "factoryId": "[concat('Microsoft.DataFactory/factories/', parameters('factoryName'))]",
+        "pipelineName": "copy_sample_data"
     },
     "resources": [
         {
@@ -77,7 +78,7 @@
             }
         },
         {
-            "name": "[concat(parameters('factoryName'), '/copy_sample_data')]",
+            "name": "[concat(parameters('factoryName'), '/', variables('pipelineName'))]",
             "type": "Microsoft.DataFactory/factories/pipelines",
             "apiVersion": "2018-06-01",
             "properties": {
@@ -136,11 +137,11 @@
     "outputs": {
         "pipelineName": {
             "type": "string",
-            "value": "copy_sample_data"
+            "value": "[variables('pipelineName')]"
         },
         "pipelineId": {
             "type": "string",
-            "value": "[concat(variables('factoryId'), '/pipelines/copy_sample_data')]"
+            "value": "[resourceId('Microsoft.DataFactory/factories/pipelines', parameters('factoryName'), 'copy_sample_data')]"
         }
     }
 }

--- a/files/sample_data/pipeline.json
+++ b/files/sample_data/pipeline.json
@@ -8,17 +8,29 @@
         "rawAdlsName": {
             "type": "string"
         },
-        "adlsLinkedService": {
+        "adlsLinkedServiceName": {
+            "type": "string"
+        },
+        "cleanNotebookPath": {
+            "type": "string"
+        },
+        "transformNotebookPath": {
+            "type": "string"
+        },
+        "databricksLinkedServiceName": {
             "type": "string"
         }
     },
     "variables": {
         "factoryId": "[concat('Microsoft.DataFactory/factories/', parameters('factoryName'))]",
-        "pipelineName": "copy_sample_data"
+        "pipelineName": "sampleDataPipeline",
+        "sampleDataLinkedServiceName": "sampleDataService",
+        "sampleDataDatasetName": "sampleDataSet",
+        "rawDataSetName": "rawData"
     },
     "resources": [
         {
-            "name": "[concat(parameters('factoryName'), '/sampledataservice')]",
+            "name": "[concat(parameters('factoryName'), '/', variables('sampleDataLinkedServiceName'))]",
             "type": "Microsoft.DataFactory/factories/linkedServices",
             "apiVersion": "2018-06-01",
             "properties": {
@@ -31,12 +43,12 @@
             }
         },
         {
-            "name": "[concat(parameters('factoryName'), '/sample_data_set')]",
+            "name": "[concat(parameters('factoryName'), '/', variables('sampleDataDatasetName'))]",
             "type": "Microsoft.DataFactory/factories/datasets",
             "apiVersion": "2018-06-01",
             "properties": {
                 "linkedServiceName": {
-                    "referenceName": "sampledataservice",
+                    "referenceName": "[variables('sampleDataLinkedServiceName')]",
                     "type": "LinkedServiceReference"
                 },
                 "type": "Json",
@@ -48,16 +60,16 @@
                 }
             },
             "dependsOn": [
-                "[concat(variables('factoryId'), '/linkedServices/sampledataservice')]"
+                "[concat(variables('factoryId'), '/linkedServices/', variables('sampleDataLinkedServiceName'))]"
             ]
         },
         {
-            "name": "[concat(parameters('factoryName'), '/raw_data')]",
+            "name": "[concat(parameters('factoryName'), '/', variables('rawDataSetName'))]",
             "type": "Microsoft.DataFactory/factories/datasets",
             "apiVersion": "2018-06-01",
             "properties": {
                 "linkedServiceName": {
-                    "referenceName": "[parameters('adlsLinkedService')]",
+                    "referenceName": "[parameters('adlsLinkedServiceName')]",
                     "type": "LinkedServiceReference"
                 },
                 "type": "Json",
@@ -115,22 +127,74 @@
                         },
                         "inputs": [
                             {
-                                "referenceName": "sample_data_set",
+                                "referenceName": "[variables('sampleDataDatasetName')]",
                                 "type": "DatasetReference"
                             }
                         ],
                         "outputs": [
                             {
-                                "referenceName": "raw_data",
+                                "referenceName": "[variables('rawDataSetName')]",
                                 "type": "DatasetReference"
                             }
                         ]
+                    },
+                    {
+                        "name": "Cleanse raw data",
+                        "type": "DatabricksNotebook",
+                        "dependsOn": [
+                            {
+                                "activity": "Copy from sample to data lake storage",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
+                            }
+                        ],
+                        "policy": {
+                            "timeout": "7.00:00:00",
+                            "retry": 0,
+                            "retryIntervalInSeconds": 30,
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "typeProperties": {
+                            "notebookPath": "[parameters('cleanNotebookPath')]"
+                        },
+                        "linkedServiceName": {
+                            "referenceName": "[parameters('databricksLinkedServiceName')]",
+                            "type": "LinkedServiceReference"
+                        }
+                    },
+                    {
+                        "name": "Transform data",
+                        "type": "DatabricksNotebook",
+                        "dependsOn": [
+                            {
+                                "activity": "Cleanse raw data",
+                                "dependencyConditions": [
+                                    "Succeeded"
+                                ]
+                            }
+                        ],
+                        "policy": {
+                            "timeout": "7.00:00:00",
+                            "retry": 0,
+                            "retryIntervalInSeconds": 30,
+                            "secureOutput": false,
+                            "secureInput": false
+                        },
+                        "typeProperties": {
+                            "notebookPath": "[parameters('transformNotebookPath')]"
+                        },
+                        "linkedServiceName": {
+                            "referenceName": "[parameters('databricksLinkedServiceName')]",
+                            "type": "LinkedServiceReference"
+                        }
                     }
                 ]
             },
             "dependsOn": [
-                "[concat(variables('factoryId'), '/datasets/sample_data_set')]",
-                "[concat(variables('factoryId'), '/datasets/raw_data')]"
+                "[concat(variables('factoryId'), '/datasets/', variables('sampleDataDatasetName'))]",
+                "[concat(variables('factoryId'), '/datasets/', variables('rawDataSetName'))]"
             ]
         }
     ],
@@ -141,7 +205,19 @@
         },
         "pipelineId": {
             "type": "string",
-            "value": "[resourceId('Microsoft.DataFactory/factories/pipelines', parameters('factoryName'), 'copy_sample_data')]"
+            "value": "[resourceId('Microsoft.DataFactory/factories/pipelines', parameters('factoryName'), variables('pipelineName'))]"
+        },
+        "sampleDataDatasetId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.DataFactory/factories/datasets', parameters('factoryName'), variables('sampleDataDatasetName'))]"
+        },
+        "rawDataSetId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.DataFactory/factories/datasets', parameters('factoryName'), variables('rawDataSetName'))]"
+        },
+        "sampleDataLinkedServiceId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.DataFactory/factories/linkedServices', parameters('factoryName'), variables('sampleDataLinkedServiceName'))]"
         }
     }
 }

--- a/files/sample_data/transform.scala
+++ b/files/sample_data/transform.scala
@@ -134,10 +134,16 @@ topGrossingDepartmentsCountriesLast30Days
 
 // COMMAND ----------
 
+val connectionString = "jdbc:sqlserver://${server}:1433;database=${database};encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;"
+
+// COMMAND ----------
+
 highestAmountsLastWeek
     .write.mode(SaveMode.Overwrite)
     .format("com.databricks.spark.sqldw")
-    .option("url", dbutils.secrets.get(scope = "synapse", key = "connection_string"))
+    .option("url", connectionString)
+    .option("user", dbutils.secrets.get(scope = "synapse", key = "username"))
+    .option("password", dbutils.secrets.get(scope = "synapse", key = "password"))
     .option("forwardSparkAzureStorageCredentials", "true")
     .option("tempDir", "wasbs://${container}@${storage_account_blob_endpoint}/highestAmountsLastWeek")
     .option("dbTable", "highestAmountsLastWeek")
@@ -148,7 +154,9 @@ highestAmountsLastWeek
 topGrossingDepartmentsLast30Days
     .write.mode(SaveMode.Overwrite)
     .format("com.databricks.spark.sqldw")
-    .option("url", dbutils.secrets.get(scope = "synapse", key = "connection_string"))
+    .option("url", connectionString)
+    .option("user", dbutils.secrets.get(scope = "synapse", key = "username"))
+    .option("password", dbutils.secrets.get(scope = "synapse", key = "password"))
     .option("forwardSparkAzureStorageCredentials", "true")
     .option("tempDir", "wasbs://${container}@${storage_account_blob_endpoint}/topGrossingDepartmentsLast30Days")
     .option("dbTable", "topGrossingDepartmentsLast30Days")
@@ -159,7 +167,9 @@ topGrossingDepartmentsLast30Days
 topSalesDepartmentsLast30Days
     .write.mode(SaveMode.Overwrite)
     .format("com.databricks.spark.sqldw")
-    .option("url", dbutils.secrets.get(scope = "synapse", key = "connection_string"))
+    .option("url", connectionString)
+    .option("user", dbutils.secrets.get(scope = "synapse", key = "username"))
+    .option("password", dbutils.secrets.get(scope = "synapse", key = "password"))
     .option("forwardSparkAzureStorageCredentials", "true")
     .option("tempDir", "wasbs://${container}@${storage_account_blob_endpoint}/topSalesDepartmentsLast30Days")
     .option("dbTable", "topSalesDepartmentsLast30Days")
@@ -170,7 +180,9 @@ topSalesDepartmentsLast30Days
 highestAmountPerSaleDepartmentsLast30Days
     .write.mode(SaveMode.Overwrite)
     .format("com.databricks.spark.sqldw")
-    .option("url", dbutils.secrets.get(scope = "synapse", key = "connection_string"))
+    .option("url", connectionString)
+    .option("user", dbutils.secrets.get(scope = "synapse", key = "username"))
+    .option("password", dbutils.secrets.get(scope = "synapse", key = "password"))
     .option("forwardSparkAzureStorageCredentials", "true")
     .option("tempDir", "wasbs://${container}@${storage_account_blob_endpoint}/highestAmountPerSaleDepartmentsLast30Days")
     .option("dbTable", "highestAmountPerSaleDepartmentsLast30Days")
@@ -181,7 +193,9 @@ highestAmountPerSaleDepartmentsLast30Days
 topGrossingCountriesLast30Days
     .write.mode(SaveMode.Overwrite)
     .format("com.databricks.spark.sqldw")
-    .option("url", dbutils.secrets.get(scope = "synapse", key = "connection_string"))
+    .option("url", connectionString)
+    .option("user", dbutils.secrets.get(scope = "synapse", key = "username"))
+    .option("password", dbutils.secrets.get(scope = "synapse", key = "password"))
     .option("forwardSparkAzureStorageCredentials", "true")
     .option("tempDir", "wasbs://${container}@${storage_account_blob_endpoint}/topGrossingCountriesLast30Days")
     .option("dbTable", "topGrossingCountriesLast30Days")
@@ -192,7 +206,9 @@ topGrossingCountriesLast30Days
 topGrossingDepartmentsCountriesLast30Days
     .write.mode(SaveMode.Overwrite)
     .format("com.databricks.spark.sqldw")
-    .option("url", dbutils.secrets.get(scope = "synapse", key = "connection_string"))
+    .option("url", connectionString)
+    .option("user", dbutils.secrets.get(scope = "synapse", key = "username"))
+    .option("password", dbutils.secrets.get(scope = "synapse", key = "password"))
     .option("forwardSparkAzureStorageCredentials", "true")
     .option("tempDir", "wasbs://${container}@${storage_account_blob_endpoint}/topGrossingDepartmentsCountriesLast30Days")
     .option("dbTable", "topGrossingDepartmentsCountriesLast30Days")


### PR DESCRIPTION
- Use Data Factory as orchestrator for the pipeline instead of relying on timestamps
- consistent ARM input/output naming
- preps for fixing #57 - every resource ID is now also an output value in the ARM templates
- fixed an issue where the Synapse password has special chars and it doesn't work in the connection string