### PR TITLE
Make vars for Synapse not required when not using Synapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The name of the data lake. This name will be used in every resource so that you 
 
 Modifying this value after deployment will result in destroying and deploying the complete data lake.
 
+**Required**\
 Type: string\
 Example: `"example name"`
 
@@ -111,6 +112,7 @@ The primary Azure region in which to deploy the data lake. Further configuration
 
 Modifying this value after deployment will result in destroying and deploying the complete data lake.
 
+**Required**\
 Type: string\
 Example: `"eastus2"`
 
@@ -167,6 +169,7 @@ Default: `[]`
 Replication strategy to be used for the data lake storage.\
 [Available options](https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy)
 
+**Required**\
 Type: string\
 Example: `"ZRS"`
 
@@ -176,6 +179,7 @@ Version of the Databricks runtime, required for the Databricks cluster.\
 [Version syntax](https://docs.databricks.com/dev-tools/api/latest/index.html#programmatic-version)\
 [Supported versions](https://docs.databricks.com/release-notes/runtime/releases.html#supported-list)
 
+**Required**\
 Type: string\
 Example: `"6.5.x-scala2.11"`
 
@@ -184,6 +188,7 @@ Example: `"6.5.x-scala2.11"`
 The Azure SKU for the Databricks workspace.\
 [Available SKUs](https://azure.microsoft.com/en-us/pricing/details/databricks/) (currently "standard" or "premium")
 
+**Required**\
 Type: string\
 Example: `"standard"`
 
@@ -191,6 +196,7 @@ Example: `"standard"`
 
 The Azure SKU for the Databricks driver and workers.
 
+**Required**\
 Type: string\
 Example: `"Standard_DS3_v2"`
 
@@ -198,6 +204,7 @@ Example: `"Standard_DS3_v2"`
 
 Lifetime (in seconds) of the Databricks access token that will be created for communication with other services in the data lake.
 
+**Required**\
 Type: number\
 Example: `315360000` (10 years)
 
@@ -206,6 +213,7 @@ Example: `315360000` (10 years)
 Default consistency level for the CosmosDB account.\
 [Available consistency levels](https://docs.microsoft.com/en-us/azure/cosmos-db/consistency-levels)
 
+**Required**\
 Type: string\
 Example: `"Session"`
 
@@ -214,6 +222,7 @@ Example: `"Session"`
 Provisioned request units for the CosmosDB account.\
 [Request units](https://docs.microsoft.com/en-us/azure/cosmos-db/request-units)
 
+**Required**\
 Type: number\
 Example: `400`
 
@@ -222,6 +231,7 @@ Example: `400`
 The provisioned Data Warehouse Units for the Azure Synapse Analytics instance. We recommend to scale this as you go.\
 [Data Warehouse Units](https://docs.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/what-is-a-data-warehouse-unit-dwu-cdwu)
 
+**Required** (unless you disable the Synapse Analytics Instance with `provision_synapse` set to `false`)\
 Type: string\
 Example: `"DW100c"`
 
@@ -229,6 +239,7 @@ Example: `"DW100c"`
 
 The admin username of the SQL server that hosts the Synapse Analytics instance.
 
+**Required** (unless you disable the Synapse Analytics Instance with `provision_synapse` set to `false`)\
 Type: string\
 Example: `"theboss"`
 
@@ -236,6 +247,7 @@ Example: `"theboss"`
 
 The password of the admin account of the SQL server that hosts the Synapse Analytics instance.
 
+**Required** (unless you disable the Synapse Analytics Instance with `provision_synapse` set to `false`)\
 Type: string\
 Example: `"ThisIsA$ecret1"`
 
@@ -243,6 +255,7 @@ Example: `"ThisIsA$ecret1"`
 
 This module uses a service principal to allow communication between the different Azure services. The service principal will no longer be valid after this time.
 
+**Required**\
 Type: string\
 Example: `"2030-01-01T00:00:00Z"`
 

--- a/test/terraform_apply_destroy_test.go
+++ b/test/terraform_apply_destroy_test.go
@@ -109,3 +109,24 @@ func TestApplyAndDestroyWithoutSamples(t *testing.T) {
 
 	assert.Equal(t, name, outDataLakeName)
 }
+
+func TestApplyAndDestroyWithoutSynapse(t *testing.T) {
+	t.Parallel()
+
+	name, options, err := getDefaultTerraformOptions(t)
+	assert.NoError(t, err)
+
+	options.Vars["provision_synapse"] = false
+	delete(options.Vars, "data_warehouse_dtu")
+	delete(options.Vars, "sql_server_admin_username")
+	delete(options.Vars, "sql_server_admin_password")
+
+	defer terraform.Destroy(t, options)
+	_, err = terraform.InitAndApplyE(t, options)
+	assert.NoError(t, err)
+
+	outDataLakeName, err := terraform.OutputE(t, options, "name")
+	assert.NoError(t, err)
+
+	assert.Equal(t, name, outDataLakeName)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,7 @@ variable "storage_replication" {
 variable "data_warehouse_dtu" {
   description = "Service objective (DTU) for the created data warehouse (e.g. DW100c)"
   type        = string
+  default     = "ignored"
 }
 
 variable "cosmosdb_consistency_level" {
@@ -98,9 +99,11 @@ variable "databricks_token_lifetime" {
 variable "sql_server_admin_username" {
   type        = string
   description = "Username of the administrator of the SQL server"
+  default     = ""
 }
 
 variable "sql_server_admin_password" {
   type        = string
   description = "Password of the administrator of the SQL server"
+  default     = ""
 }


### PR DESCRIPTION
* make Synapse config vars optional
* add docs on which vars are optional and which are not
* add test that does not use the Synapse instance